### PR TITLE
Add sequencing depth quartiles to metadata

### DIFF
--- a/xebec/src/_depth.py
+++ b/xebec/src/_depth.py
@@ -1,0 +1,19 @@
+import biom
+import numpy as np
+import pandas as pd
+
+
+def map_quartiles(depths):
+    q1, q2, q3 = np.quantile(depths, [0.25, 0.50, 0.75])
+    quartiles = []
+    for value in depths:
+        if value < q1:
+            q = "q1"
+        elif q1 <= value < q2:
+            q = "q2"
+        elif q2 <= value < q3:
+            q = "q3"
+        else:
+            q = "q4"
+        quartiles.append(q)
+    return quartiles

--- a/xebec/tests/test_depth.py
+++ b/xebec/tests/test_depth.py
@@ -1,0 +1,10 @@
+import numpy as np
+
+from xebec.src._depth import map_quartiles
+
+
+def test_map_quartiles():
+    depths = np.linspace(0, 100, 100)
+    quartiles = map_quartiles(depths)
+    for q in ["q1", "q2", "q3", "q4"]:
+        assert quartiles.count(q) == 25

--- a/xebec/{{cookiecutter.project_name}}/workflow/rules/preprocess_data.smk
+++ b/xebec/{{cookiecutter.project_name}}/workflow/rules/preprocess_data.smk
@@ -1,6 +1,7 @@
 rule filter_metadata:
     input:
-        "{{cookiecutter.sample_metadata_file}}"
+        md_file = "{{cookiecutter.sample_metadata_file}}",
+        tbl_file = "{{cookiecutter.feature_table_file}}"
     output:
         "results/filtered_metadata.tsv"
     log:

--- a/xebec/{{cookiecutter.project_name}}/workflow/scripts/run_evident.py
+++ b/xebec/{{cookiecutter.project_name}}/workflow/scripts/run_evident.py
@@ -31,6 +31,7 @@ elif snakemake.params["pairwise"] == "False":
 else:
     pass
 
+
 xebec_logger.info(f"Diversity Metric: {div_metric}")
 xebec_logger.info("Calculating effect sizes...")
 res = func(dh, md.columns).to_dataframe()


### PR DESCRIPTION
Idea came up at code review. Adds the sequencing depth of each sample as a metadata column (in quartiles). Note that this does not affect rarefaction - effect sizes are still calculated from the rarefied tables but the original depths are included now.