### PR TITLE
Update install instructions and Bokeh HoverTool 'names' deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ To use xebec, you will need several dependencies.
 We recommend using [`mamba`](https://github.com/mamba-org/mamba) to install these packages when possible.
 
 ```
-mamba install -c conda-forge -c bioconda biom-format h5py==3.1.0 snakemake pandas unifrac scikit-bio bokeh unifrac-binaries jinja2
-
+mamba install -c conda-forge -c bioconda biom-format h5py==3.1.0 scipy==1.8 numpy==1.23 snakemake pandas unifrac scikit-bio bokeh unifrac-binaries jinja2
 pip install evident>=0.4.0 gemelli>=0.0.8
 ```
 

--- a/gurobi.log
+++ b/gurobi.log
@@ -1,0 +1,6 @@
+
+Gurobi 8.1.0 (mac64) logging started Mon May  1 11:50:15 2023
+
+
+ERROR 10009: No Gurobi license found (user yac027, host knightlab.local, hostid 9fe21529, cores 4)
+

--- a/xebec/gurobi.log
+++ b/xebec/gurobi.log
@@ -1,0 +1,12 @@
+
+Gurobi 8.1.0 (mac64) logging started Mon May  1 11:50:29 2023
+
+
+ERROR 10009: No Gurobi license found (user yac027, host knightlab.local, hostid 9fe21529, cores 4)
+
+
+Gurobi 8.1.0 (mac64) logging started Wed May 10 09:37:49 2023
+
+
+ERROR 10009: No Gurobi license found (user yac027, host knightlab.local, hostid 9fe21529, cores 4)
+

--- a/xebec/src/_visualization.py
+++ b/xebec/src/_visualization.py
@@ -1,6 +1,6 @@
 from bokeh.models import ColumnDataSource, HoverTool
 import seaborn as sns
-
+import pandas as pd
 
 # Figure parameters
 TITLE_FONT_SIZE = "20pt"
@@ -27,13 +27,17 @@ SCATTER_PHYLO_MARKER = "triangle"
 SCATTER_NON_PHYLO_PALETTE = "Reds"
 SCATTER_NON_PHYLO_MARKER = "circle"
 
-HOVER_POINTS = HoverTool(mode="mouse", names=["points"], attachment="below")
+# HOVER_POINTS = HoverTool(mode="mouse", names=["points"], attachment="below")
+HOVER_POINTS = HoverTool(mode="mouse", tooltips=[("Name", "points")], attachment="below")
+
 HOVER_POINTS.tooltips = [
     ("Effect Size", "@effect_size{0.000}"),
     ("Diversity Metric", "@diversity_metric")
 ]
 
-HOVER_BOXES = HoverTool(mode="mouse", names=["boxes"], attachment="above")
+# HOVER_BOXES = HoverTool(mode="mouse", names=["boxes"], attachment="above")
+HOVER_BOXES = HoverTool(mode="mouse", tooltips=[("Name", "boxes")], attachment="above")
+
 HOVER_BOXES.tooltips = [
     ("25%", "@q1{0.000}"),
     ("50%", "@q2{0.000}"),
@@ -41,7 +45,7 @@ HOVER_BOXES.tooltips = [
 ]
 
 
-def add_boxplots(figure, all_metrics_es_df, group_var) -> None:
+def add_boxplots(figure, all_metrics_es_df:pd.DataFrame, group_var:str) -> None:
     """Add boxplots to figure."""
     gb = all_metrics_es_df.groupby(group_var)["effect_size"]
     q1 = gb.quantile(q=0.25)
@@ -59,7 +63,7 @@ def add_boxplots(figure, all_metrics_es_df, group_var) -> None:
     lower = [max([x, y]) for (x, y) in zip(list(qmin), lower)]
 
     box_df = (
-        all_metrics_es_df.groupby(group_var)
+        all_metrics_es_df.groupby(group_var)["effect_size"]
         .median()
         .assign(q1=q1, q2=q2, q3=q3,
                 qmin=qmin, qmax=qmax,

--- a/xebec/src/_visualization.py
+++ b/xebec/src/_visualization.py
@@ -27,17 +27,13 @@ SCATTER_PHYLO_MARKER = "triangle"
 SCATTER_NON_PHYLO_PALETTE = "Reds"
 SCATTER_NON_PHYLO_MARKER = "circle"
 
-# HOVER_POINTS = HoverTool(mode="mouse", names=["points"], attachment="below")
 HOVER_POINTS = HoverTool(mode="mouse", tooltips=[("Name", "points")], attachment="below")
-
 HOVER_POINTS.tooltips = [
     ("Effect Size", "@effect_size{0.000}"),
     ("Diversity Metric", "@diversity_metric")
 ]
 
-# HOVER_BOXES = HoverTool(mode="mouse", names=["boxes"], attachment="above")
 HOVER_BOXES = HoverTool(mode="mouse", tooltips=[("Name", "boxes")], attachment="above")
-
 HOVER_BOXES.tooltips = [
     ("25%", "@q1{0.000}"),
     ("50%", "@q2{0.000}"),

--- a/xebec/workflow/gurobi.log
+++ b/xebec/workflow/gurobi.log
@@ -1,0 +1,6 @@
+
+Gurobi 8.1.0 (mac64) logging started Mon May  1 11:51:07 2023
+
+
+ERROR 10009: No Gurobi license found (user yac027, host knightlab.local, hostid 9fe21529, cores 4)
+

--- a/xebec/workflow/rules/visualization.smk
+++ b/xebec/workflow/rules/visualization.smk
@@ -5,7 +5,7 @@ import seaborn as sns
 
 
 def get_div_metrics(wildcards):
-    if wildcards.diversity_type == "alpha_div":
+    if  wildcards.diversity_type == "alpha_div":
         return alpha_metrics["diversity_metric"].tolist()
     else:
         return beta_metrics["diversity_metric"].tolist()

--- a/xebec/workflow/scripts/interactive_effect_sizes.py
+++ b/xebec/workflow/scripts/interactive_effect_sizes.py
@@ -12,9 +12,9 @@ def generate_interactive_effect_sizes(es_metric: str):
 
     # Order columns by median effect size
     order = list(
-        _df.groupby("column")
+        _df.groupby("column")["effect_size"]
         .median()
-        .sort_values(by="effect_size", ascending=False).index
+        .sort_values(ascending=False).index
     )
 
     # https://stackoverflow.com/a/27255567

--- a/xebec/workflow/scripts/interactive_pw_effect_sizes.py
+++ b/xebec/workflow/scripts/interactive_pw_effect_sizes.py
@@ -8,7 +8,6 @@ import pandas as pd
 
 import xebec.src._visualization as viz
 
-
 diversity_metric_order = snakemake.params["all_div_metrics"]
 non_phylo_metrics = snakemake.params["non_phylo_metrics"]
 phylo_metrics = snakemake.params["phylo_metrics"]
@@ -35,11 +34,9 @@ comparisons = col_df["comparison"].unique()
 div_metrics = col_df["diversity_metric"].unique()
 
 order = list(
-    col_df
-    .groupby("comparison")
+    df.groupby("column")["effect_size"]
     .median()
-    .sort_values(by="effect_size", ascending=False)
-    .index
+    .sort_values(ascending=False).index
 )
 
 hover_points = viz.HOVER_POINTS
@@ -48,7 +45,6 @@ hover_boxes = viz.HOVER_BOXES
 p = figure(
     tools=["pan", "reset", "box_zoom", hover_boxes, hover_points],
     y_range=order,
-    sizing_mode="stretch_both"
 )
 
 big_source = ColumnDataSource(df)


### PR DESCRIPTION
SciPy pinned to 1.8: https://github.com/biocore/scikit-bio/issues/1818
Numpy pinned to 1.23: https://github.com/WongKinYiu/yolov7/issues/1280

Minimum version of Bokeh 2.3.0 is required for Xebec.

See version update notes for Bokeh 2.3.0, released February 2021 (below): https://docs.bokeh.org/en/2.4.1/docs/releases.html
names properties were deprecated
DataRange.names, SelectTool.names, and HoverTool.names are deprecated and will be removed in Bokeh 3.0. Use the renderers properties instead, possibly in combination with plot.select(name="renderer name").

Tested on Bokeh 3.1.0.